### PR TITLE
Fix order of newline replacing and HTML escaping

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -145,8 +145,8 @@ useridlistid
         $days = $robot::get_config()->recentactivity;
         $count = count($robot->get_recentcourses());
         $recentactivitydesc = get_string('recentactivitydesc', 'tool_crawler', ['days' => $days, 'count' => $count]);
+        $recentactivitydesc = htmlspecialchars($recentactivitydesc, ENT_NOQUOTES | ENT_HTML401);
         $recentactivitydesc = preg_replace('/(\r\n?|\n)/', '<br>', $recentactivitydesc);
-        $recentactivitydesc = htmlentities($recentactivitydesc, ENT_NOQUOTES | ENT_HTML5);
         $settings->add(new admin_setting_configtext('tool_crawler/recentactivity',
                                                     new lang_string('recentactivity',    'tool_crawler'),
                                                     $recentactivitydesc,

--- a/url.php
+++ b/url.php
@@ -42,8 +42,8 @@ echo $OUTPUT->header();
 
 echo $OUTPUT->heading(get_string('urldetails', 'tool_crawler'));
 $urldetailshelp = get_string('urldetails_help', 'tool_crawler');
+$urldetailshelp = htmlspecialchars($urldetailshelp, ENT_NOQUOTES | ENT_HTML401);
 $urldetailshelp = preg_replace('/(\r\n?|\n)/', '<br>', $urldetailshelp);
-$urldetailshelp = htmlentities($urldetailshelp, ENT_NOQUOTES | ENT_HTML5);
 echo '<p>' . $urldetailshelp . '</p>';
 
 $urlrec = $DB->get_record('tool_crawler_url', array('url' => $url));


### PR DESCRIPTION
I’ve made a mistake in pull request #57, which this pull request fixes:
the code produced strings like `'first line&lt;br&gt;second line'` instead of `'first line<br>second line'`.

The bug went undetected, and I’m very sorry about that.

This pull request contains a commit that fixes the newly-introduced bug.