### PR TITLE
Remaining fixes related to safe value handling and HTML output

### DIFF
--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -338,7 +338,7 @@ class crawler {
                 $shortname = $course->shortname;
             }
         }
-        if ($shortname) {
+        if ($shortname !== '' && $shortname !== null) {
             $bad = 0;
             $excludes = str_replace("\r", '', self::get_config()->excludecourses);
             $excludes = explode("\n", $excludes);

--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -83,7 +83,7 @@ class crawler {
         }
         if ($result->redirect) {
             return get_string('bottestpageredirected', 'tool_crawler',
-                array('resredirect' => $result->redirect));
+                array('resredirect' => htmlspecialchars($result->redirect, ENT_NOQUOTES | ENT_HTML401)));
         }
 
         // When the bot successfully scraped the test page (see above), it was logged in and used its own language. So we have to

--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -60,7 +60,7 @@ class crawler {
     /**
      * Checks that the bot user exists and password works etc
      *
-     * @return mixed true or a error string
+     * @return null|string On success, null. In the case of failure, an error string (which is an HTML snippet).
      */
     public function is_bot_valid() {
 

--- a/locallib.php
+++ b/locallib.php
@@ -127,7 +127,7 @@ function tool_crawler_url_gen_table($data) {
             $code,
             display_size($size),
             tool_crawler_link($row->target, $title, $row->redirect),
-            $row->mimetype,
+            htmlspecialchars($row->mimetype, ENT_NOQUOTES | ENT_HTML401),
         );
         $table->data[] = $data;
     }

--- a/locallib.php
+++ b/locallib.php
@@ -72,6 +72,7 @@ function tool_crawler_http_code($row) {
     } else {
         $msg = isset($row->httpmsg) ? $row->httpmsg : '?';
     }
+    $msg = htmlspecialchars($msg, ENT_NOQUOTES | ENT_HTML401);
 
     $code = $row->httpcode;
     $cc = substr($code, 0, 1);

--- a/locallib.php
+++ b/locallib.php
@@ -166,7 +166,7 @@ function tool_crawler_url_create_page($url) {
     $urlrec = $DB->get_record('tool_crawler_url', array('url' => $url));
     $page .= '<h2>' . tool_crawler_link($url, $urlrec->title, $urlrec->redirect) . '</h2>';
 
-    $page .= '<h3>' . get_string('outgoingurls', 'tool_crawler') . '</h3>';
+    $page .= '<h3>' . htmlspecialchars(get_string('outgoingurls', 'tool_crawler'), ENT_NOQUOTES | ENT_HTML401) . '</h3>';
 
     $data  = $DB->get_records_sql("
          SELECT concat(l.a, '-', l.b) AS id,
@@ -194,7 +194,7 @@ function tool_crawler_url_create_page($url) {
 
     $page .= tool_crawler_url_gen_table($data);
 
-    $page .= '<h3>' . get_string('incomingurls', 'tool_crawler') . '</h3>';
+    $page .= '<h3>' . htmlspecialchars(get_string('incomingurls', 'tool_crawler'), ENT_NOQUOTES | ENT_HTML401) . '</h3>';
 
     $data  = $DB->get_records_sql("
          SELECT concat(l.a, '-', l.b) AS id,

--- a/locallib.php
+++ b/locallib.php
@@ -50,10 +50,10 @@ function tool_crawler_link($url, $label, $redirect = '', $labelishtml = false) {
     $html = html_writer::link(new moodle_url('url.php', array('url' => $url)), $label) .
             ' ' .
             html_writer::link($url, '↗', array('target' => 'link')) .
-            '<br><small>' . htmlspecialchars($url) . '</small>';
+            '<br><small>' . htmlspecialchars($url, ENT_NOQUOTES | ENT_HTML401) . '</small>';
 
     if ($redirect) {
-        $linkhtmlsnippet = html_writer::link($redirect, htmlspecialchars($redirect, ENT_NOQUOTES | ENT_HTML5));
+        $linkhtmlsnippet = html_writer::link($redirect, htmlspecialchars($redirect, ENT_NOQUOTES | ENT_HTML401));
         $html .= "<br>" . get_string('redirect', 'tool_crawler', array('redirectlink' => $linkhtmlsnippet));
     }
 

--- a/report.php
+++ b/report.php
@@ -143,7 +143,8 @@ if ($report == 'broken') {
             tool_crawler_link($row->url, $row->title, $row->redirect)
         );
         if (!$courseid) {
-            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $row->shortname) );
+            $escapedshortname = htmlspecialchars($row->shortname, ENT_NOQUOTES | ENT_HTML401);
+            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $escapedshortname) );
         }
         $table->data[] = $data;
     }
@@ -195,7 +196,8 @@ if ($report == 'broken') {
             tool_crawler_link($row->target, $title, $row->redirect)
         );
         if (!$courseid) {
-            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $row->shortname) );
+            $escapedshortname = htmlspecialchars($row->shortname, ENT_NOQUOTES | ENT_HTML401);
+            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $escapedshortname) );
         }
         $table->data[] = $data;
     }
@@ -257,7 +259,8 @@ if ($report == 'broken') {
             htmlspecialchars($row->mimetype, ENT_NOQUOTES | ENT_HTML401),
         );
         if (!$courseid) {
-            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $row->shortname) );
+            $escapedshortname = htmlspecialchars($row->shortname, ENT_NOQUOTES | ENT_HTML401);
+            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $escapedshortname) );
         }
         $table->data[] = $data;
     }
@@ -329,7 +332,8 @@ if ($report == 'broken') {
             tool_crawler_link($row->url, $row->title, $row->redirect)
         );
         if (!$courseid) {
-            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $row->shortname) );
+            $escapedshortname = htmlspecialchars($row->shortname, ENT_NOQUOTES | ENT_HTML401);
+            array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $escapedshortname) );
         }
         $table->data[] = $data;
     }

--- a/report.php
+++ b/report.php
@@ -254,7 +254,7 @@ if ($report == 'broken') {
             $code,
             display_size($size),
             tool_crawler_link($row->target, $title, $row->redirect),
-            $row->mimetype,
+            htmlspecialchars($row->mimetype, ENT_NOQUOTES | ENT_HTML401),
         );
         if (!$courseid) {
             array_push($data, html_writer::link('/course/view.php?id='.$row->courseid, $row->shortname) );
@@ -325,7 +325,7 @@ if ($report == 'broken') {
             userdate($row->lastcrawled, $datetimeformat),
             display_size($size),
             tool_crawler_link($row->target, $text, $row->redirect, true),
-            $row->mimetype,
+            htmlspecialchars($row->mimetype, ENT_NOQUOTES | ENT_HTML401),
             tool_crawler_link($row->url, $row->title, $row->redirect)
         );
         if (!$courseid) {


### PR DESCRIPTION
Escape HTML strings on output, especially those which are not under our control.

This pull request also contains minor changes which are not _directly_ related to HTML output, but which relate to proper handling of values read from the outside.

This completes our output escaping work.