### PR TITLE
Delete cookie jar on plugin uninstallation

### DIFF
--- a/db/uninstall.php
+++ b/db/uninstall.php
@@ -1,0 +1,40 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Link checker robot plugin uninstall script.
+ *
+ * @package    tool_crawler
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Hook called just before the plugin is uninstalled. Removes the cookie jar which had been used by the plugin if it exists.
+ *
+ * @return bool Whether the function was successful.
+ */
+function xmldb_tool_crawler_uninstall() {
+    global $CFG;
+
+    $cookiefile = $CFG->dataroot . '/tool_crawler_cookies.txt';
+    if (file_exists($cookiefile)) {
+        @unlink($cookiefile);
+    }
+
+    return true;
+}


### PR DESCRIPTION
Make use of an uninstall script to delete the cookie jar when the plugin
is uninstalled. This ensures that we do not leave the file lying around.
A failure to delete the cookie jar is silently ignored.

It is unnecessary to keep the cookie jar for the future in case the
plugin is installed again, as new cookies will be created and written to
the jar.

Please verify that this pull request is okay because I haven’t yet had the possibility to test the new code.