### PR TITLE
When crawler is redirected, do not show HTTP status codes and messages that do not match

### DIFF
--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -910,8 +910,11 @@ class crawler {
         } else {
             $headersize = curl_getinfo($s, CURLINFO_HEADER_SIZE);
             $headers = substr($raw, 0, $headersize);
-            $header = strtok($headers, "\n");
-            $result->httpmsg          = explode(" ", $header, 3)[2];
+            if (preg_match_all('@(^|[\r\n])(HTTP/[^ ]+) ([0-9]+) ([^\r\n]+|$)@', $headers, $httplines, PREG_SET_ORDER)) {
+                $result->httpmsg = array_pop($httplines)[4];
+            } else {
+                $result->httpmsg = '';
+            }
 
             $ishtml = (strpos($contenttype, 'text/html') === 0); // Related to Issue #13.
             $data = $ishtml ? substr($raw, $headersize) : '';


### PR DESCRIPTION
We have found that the reports of the bot show the first textual HTTP response message and the last HTTP status code. In case of redirects, it is common that these do not match.

This has already reported twice by users, it seems, in #36 and #37. Both issues seem to have the same cause. This pull request fixes both of them.

Merging this pull request should result in reports that are easier for users to understand, and are less confusing.