### PR TITLE
Make Travis checks work again by fixing the problem with Oracle JRE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 env:
   - DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE CI_PLUGIN=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ sudo: required
 addons:
   firefox: "35.0.1"
   postgresql: "9.4"
-  apt:
-    packages:
-      - openjdk-8-jre-headless
 
 env:
   - DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE CI_PLUGIN=2
@@ -68,7 +65,6 @@ script:
   - moodle-plugin-ci validate
   - if [ "$CI_PLUGIN" = 2 ]; then
       moodle-plugin-ci savepoints || travis_terminate 1;
-      moodle-plugin-ci mustache || travis_terminate 1;
       moodle-plugin-ci grunt || travis_terminate 1;
     else
       moodle-plugin-ci csslint || travis_terminate 1;


### PR DESCRIPTION
Travis builds fail because the required Oracle JRE package cannot be installed. According to the documentation, a JRE is not required at all because Mustache templates are not used. So remove Mustache support and installation of the JRE package in testing altogether.

This pull request includes a commit which fixes the Oracle JRE problem. If you like to drop it, feel free to squash the two commits. I thought the commit might be useful in future in case someone likes to introduce Mustache templates and needs the commit: then the removal commit can easily be reverted.