### PR TITLE
Update stored metainformation on recrawls

### DIFF
--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -576,6 +576,13 @@ class crawler {
         if ($verbose) {
             echo "Crawling $node->url ";
         }
+
+        // Function scrape writes to the title property only if there has been a download error. The title may be set by function
+        // parse_html later. If it is not, we do not have a valid title. In order to have the _proper_ title (set or null) stored in
+        // the database in the end in case of recrawls, we must clear the existing title here (only to maybe re-add it in a few
+        // fractions of a second).
+        $node->title = null;
+
         // Scraping returns info about the URL. Not info about the courseid and context, just the URL itself.
         $result = $this->scrape($node->url);
         $result = (object) array_merge((array) $node, (array) $result);

--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -928,6 +928,7 @@ class crawler {
             $result->title            = curl_error($s); // We do not try to translate Curl error messages.
             $result->contents         = '';
             $result->httpcode         = '500';
+            $result->httpmsg          = null;
         } else {
             $result->errormsg = null;  // Important in case of repeated scraping in order to reset error status.
 

--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -929,6 +929,8 @@ class crawler {
             $result->contents         = '';
             $result->httpcode         = '500';
         } else {
+            $result->errormsg = null;  // Important in case of repeated scraping in order to reset error status.
+
             $headersize = curl_getinfo($s, CURLINFO_HEADER_SIZE);
             $headers = substr($raw, 0, $headersize);
             if (preg_match_all('@(^|[\r\n])(HTTP/[^ ]+) ([0-9]+) ([^\r\n]+|$)@', $headers, $httplines, PREG_SET_ORDER)) {

--- a/locallib.php
+++ b/locallib.php
@@ -67,7 +67,7 @@ function tool_crawler_link($url, $label, $redirect = '', $labelishtml = false) {
  * @return html chunk
  */
 function tool_crawler_http_code($row) {
-    if (isset($row->errormsg)) {
+    if (isset($row->errormsg) && !is_null($row->errormsg)) {
         $msg = get_string('fetcherror', 'tool_crawler', ['errormessage' => $row->errormsg]);
     } else {
         $msg = isset($row->httpmsg) ? $row->httpmsg : '?';

--- a/locallib.php
+++ b/locallib.php
@@ -70,7 +70,7 @@ function tool_crawler_http_code($row) {
     if (isset($row->errormsg) && !is_null($row->errormsg)) {
         $msg = get_string('fetcherror', 'tool_crawler', ['errormessage' => $row->errormsg]);
     } else {
-        $msg = isset($row->httpmsg) ? $row->httpmsg : '?';
+        $msg = isset($row->httpmsg) && !is_null($row->httpmsg) ? $row->httpmsg : '?';
     }
     $msg = htmlspecialchars($msg, ENT_NOQUOTES | ENT_HTML401);
 


### PR DESCRIPTION
When crawling or scraping a resource for the n-th time (n>1), the metainformation which is stored in the database needs to be updated. This means especially the columns for document title, download error status and HTTP status-line.

This ensures correct display in reports, as well as a clean database. The former is important to users; the latter is convenient for developers when debugging the plugin.