### PR TITLE
Requeue course and module pages immediately when they are updated

### DIFF
--- a/classes/event/observer.php
+++ b/classes/event/observer.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Event observers used in tool_crawler
+ *
+ * @package    tool_crawler
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_crawler\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Event observer for tool_crawler.
+ */
+class observer {
+    /**
+     * Triggered via course_updated event.
+     *
+     * @param \core\event\course_updated $event
+     */
+    public static function course_updated(\core\event\course_updated $event) {
+        global $CFG;
+
+        $courseid = $event->objectid;
+        $crawler = new \tool_crawler\robot\crawler();
+        return $crawler->mark_for_crawl($CFG->wwwroot . '/', 'course/view.php?id=' . $courseid, $courseid);
+    }
+    /**
+     * When a course_module is updated, queue up that page for recrawling again immediately
+     *
+     * @param \core\event\course_module_updated $event
+     * @return boolean
+     */
+    public static function course_module_updated(\core\event\course_module_updated $event) {
+        global $CFG;
+
+        $cmid = $event->objectid;
+        $crawler = new \tool_crawler\robot\crawler();
+        // Get the name of module to build the correct url.
+        $modulename = $event->get_data()['other']['modulename'];
+        return $crawler->mark_for_crawl($CFG->wwwroot . '/', 'mod/' . $modulename . '/view.php?id=' . $cmid);
+    }
+}

--- a/db/events.php
+++ b/db/events.php
@@ -14,24 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 /**
- * Defines the version of tool_crawler
+ * This file defines observers needed by the plugin tool_crawler
  *
  * @package    tool_crawler
- * @author     Brendan Heywood <brendan@catalyst-au.net>
- * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-
-$plugin->version   = 2019100100;        // The current plugin version (Date: YYYYMMDDXX)
-$plugin->release   = 2018070200;        // The current plugin version (Date: YYYYMMDDXX)
-$plugin->requires  = 2016021800;        // Requires this Moodle version.
-$plugin->component = 'tool_crawler'; // To check on upgrade, that module sits in correct place.
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->dependencies = array(
-    'auth_basic' => ANY_VERSION,
-);
+// List of observers.
+$observers = [
+    [
+        'eventname' => '\core\event\course_updated',
+        'callback'  => '\tool_crawler\event\observer::course_updated',
+    ],
+    [
+        'eventname' => '\core\event\course_module_updated',
+        'callback'  => '\tool_crawler\event\observer::course_module_updated',
+    ],
+];


### PR DESCRIPTION
mark_for_crawl adds a url to the end of the queue. Maybe we need another function to add to the front of the queue?
