### PR TITLE
Extend cli/crawler.php to let the admin set the verbosity level

### DIFF
--- a/cli/crawler.php
+++ b/cli/crawler.php
@@ -29,5 +29,28 @@ require(dirname(dirname(dirname(dirname(dirname(__FILE__))))).'/config.php');
 require_once($CFG->libdir.'/clilib.php');
 require_once($CFG->dirroot .'/admin/tool/crawler/lib.php');
 
-tool_crawler_crawl(1);
+list($options, $unrecognized) = cli_get_params(array(
+        'help'      => false,
+        'verbose'   => 1,
+),
+        array(
+                'h' => 'help'
+        ));
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    echo get_string('clicrawlerhelp', 'tool_crawler');
+    die();
+}
+
+if ($options['verbose'] && (!is_numeric($options['verbose']) || $options['verbose'] < 0 || $options['verbose'] > 2)) {
+    echo get_string('clicrawlerhelp', 'tool_crawler');
+    die();
+}
+
+tool_crawler_crawl($options['verbose']);
 

--- a/lang/en/tool_crawler.php
+++ b/lang/en/tool_crawler.php
@@ -49,6 +49,15 @@ Options:
 Example:
 $sudo -u www-data php crawl-as.php --url=https://host.example/
 ';
+$string['clicrawlerhelp'] = 'Run the crawler manually without having to wait for the scheduled task.
+
+Options:
+-h, --help          Print out this help
+--verbose=<level>   Verbosity level (0 = Quiet, 1 = Standard verbosity, 2 = Extended verbosity), Default: 1
+
+Example:
+$sudo -u www-data php crawler.php --verbose=1
+';
 $string['clierror'] = 'Error: {$a}';
 $string['cliscrapeashelp'] = 'Scrape the URL as the robot would see it, but do not process/queue it.
 


### PR DESCRIPTION
Hi all,

this extension should be quite straightforward and does not need much explanation. I found it useful to be able to set the verbosity level on command line instead of having to hack the script everytime I wanted also to see the links which were found on a page.

Cheers,
Alex