### PR TITLE
Include constants file in settings.php

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 defined('MOODLE_INTERNAL') || die;
+require_once($CFG->dirroot . '/admin/tool/crawler/constants.php');
 
 if ($hassiteconfig) {
 


### PR DESCRIPTION
Since we removed the `$robot = new \tool_crawler\robot\crawler();` line from our settings file, we get warnings that our constants are undefined. We need to include these. 