### PR TITLE
Improved UX for tabs

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -151,34 +151,19 @@ function tool_crawler_summary($courseid) {
  * @param context $coursecontext The context of the course
  */
 function tool_crawler_extend_navigation_course($navigation, $course, $coursecontext) {
-    $reports = array('queued', 'recent', 'broken', 'oversize');
-
     $coursereports = $navigation->get('coursereports');
     if (!$coursereports) {
         return; // Course reports submenu in "course administration" not available.
     }
 
     if ($coursereports) {
-        $url = new moodle_url('/admin/tool/crawler/report.php', array('report' => 'recent', 'course' => $course->id));
-        $node = $coursereports->add(
+        $coursereports->add(
             get_string('pluginname', 'tool_crawler'),
-            $url,
+            new moodle_url('/admin/tool/crawler/report.php', array('report' => 'queued', 'course' => $course->id)),
             navigation_node::TYPE_CONTAINER,
             null,
             'linkchecker',
             new pix_icon('i/report', get_string('pluginname', 'tool_crawler'))
         );
-
-        foreach ($reports as $rpt) {
-            $url = new moodle_url('/admin/tool/crawler/report.php', array('report' => $rpt, 'course' => $course->id));
-            $node->add(
-                get_string($rpt, 'tool_crawler'),
-                $url,
-                navigation_node::TYPE_SETTING,
-                null,
-                null,
-                new pix_icon('i/report', '')
-            );
-        }
     }
 }

--- a/report.php
+++ b/report.php
@@ -54,10 +54,13 @@ if ($courseid) {
     $coursecontext = context_course::instance($courseid);
     require_capability('moodle/course:update', $coursecontext);
 
+    $coursename = format_string($course->fullname, true, array('context' => $coursecontext));
     $PAGE->set_context($coursecontext);
     $PAGE->set_url($navurl);
-    $PAGE->set_pagelayout('admin');
     $PAGE->set_title( get_string($report, 'tool_crawler') );
+    $PAGE->set_heading($coursename);
+    $PAGE->set_pagelayout('incourse');
+    $PAGE->add_body_class('limitedwidth');
     $sqlfilter = ' AND c.id = '.$courseid;
 
 } else {

--- a/tabs.php
+++ b/tabs.php
@@ -24,20 +24,30 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$rows = [
+$adminrows = [
     new tabobject('settings', new moodle_url('/admin/settings.php?section=tool_crawler'),
         get_string('settings', 'tool_crawler')),
     new tabobject('index',    new moodle_url('/admin/tool/crawler/index.php'),
-        get_string('status',   'tool_crawler')),
-    new tabobject('queued',   new moodle_url('/admin/tool/crawler/report.php?report=queued'),
-        get_string('queued',   'tool_crawler')),
-    new tabobject('recent',   new moodle_url('/admin/tool/crawler/report.php?report=recent'),
-        get_string('recent',   'tool_crawler')),
-    new tabobject('broken',   new moodle_url('/admin/tool/crawler/report.php?report=broken'),
-        get_string('broken',   'tool_crawler')),
-    new tabobject('oversize', new moodle_url('/admin/tool/crawler/report.php?report=oversize'),
-        get_string('oversize', 'tool_crawler')),
+        get_string('status',   'tool_crawler'))
 ];
+
+$courseid = optional_param('course', 0, PARAM_INT);
+$courseparam = $courseid ? ['course' => $courseid] : [];
+$courserows = [
+    new tabobject('queued',   new moodle_url('/admin/tool/crawler/report.php', ['report' => 'queued'] + $courseparam),
+        get_string('queued',   'tool_crawler')),
+    new tabobject('recent',   new moodle_url('/admin/tool/crawler/report.php', ['report' => 'recent'] + $courseparam),
+        get_string('recent',   'tool_crawler')),
+    new tabobject('broken',   new moodle_url('/admin/tool/crawler/report.php', ['report' => 'broken'] + $courseparam),
+        get_string('broken',   'tool_crawler')),
+    new tabobject('oversize', new moodle_url('/admin/tool/crawler/report.php', ['report' => 'oversize'] + $courseparam),
+        get_string('oversize', 'tool_crawler'))
+];
+
+$rows = array_merge(
+    has_capability('moodle/site:config', context_system::instance()) ? $adminrows : [],
+    $courserows
+);
 
 $section = optional_param('section', '', PARAM_RAW);
 if ($section == 'tool_crawler') {


### PR DESCRIPTION
tabs.php now only shows admin tabs when the user has the correct permission. The tabs now also append a course id so that when they are accessed via course reports, the user isn't navigated away to the system level reports.

PR for master branch here: https://github.com/catalyst/moodle-tool_crawler/pull/160