### PR TITLE
Improve report link navigation

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -49,10 +49,9 @@ function tool_crawler_link($url, $label, $redirect = '', $labelishtml = false) {
         $label = htmlspecialchars($label, ENT_NOQUOTES | ENT_HTML401);
     }
 
-    $html = html_writer::link(new moodle_url('url.php', array('url' => $url)), $label) .
-            ' ' .
-            html_writer::link($url, '↗', array('target' => 'link')) .
-            '<br><small>' . htmlspecialchars($url, ENT_NOQUOTES | ENT_HTML401) . '</small>';
+    $canviewsitelevelreports = has_capability('moodle/site:config', context_system::instance());
+    $html = $canviewsitelevelreports ? html_writer::link(new moodle_url('url.php', array('url' => $url)), $label) : $label;
+    $html .= '<br><small>' . html_writer::link($url, htmlspecialchars($url, ENT_NOQUOTES | ENT_HTML401), ['target' => 'link']) . '</small>';
 
     if ($redirect) {
         $linkhtmlsnippet = html_writer::link($redirect, htmlspecialchars($redirect, ENT_NOQUOTES | ENT_HTML401));

--- a/tests/phpunit/robot_crawler_test.php
+++ b/tests/phpunit/robot_crawler_test.php
@@ -224,11 +224,12 @@ class tool_crawler_robot_crawler_test extends advanced_testcase {
         $expectedpattern = '@' .
                 preg_quote('<h2>', '@') .
                 '.*' .
-                preg_quote('<a ', '@') .
+                preg_quote('<br><small><a', '@') .
                 '[^>]*' . // XXX: Not *100%* reliable, as '>' *might* be contained in attribute values.
-                preg_quote('href="' . $escapedexpected . '">↗</a><br><small>' . $escapedexpected . '</small>', '@') .
+                preg_quote('href="' . $escapedexpected . '">' . $escapedexpected . '</a></small>', '@') .
                 '@';
-        self::assertRegExp($expectedpattern, $page);
+
+        self::assertMatchesRegularExpression($expectedpattern, $page);
     }
 
     /**
@@ -273,7 +274,7 @@ class tool_crawler_robot_crawler_test extends advanced_testcase {
                 '.*' .
                 preg_quote('<br>Redirect: <a href="' . $escapedredirecturl . '">' . $escapedredirecturl . '</a></h2>', '@') .
                 '@';
-        self::assertRegExp($expectedpattern, $page);
+        self::assertMatchesRegularExpression($expectedpattern, $page);
     }
 
     /**


### PR DESCRIPTION
- Link titles are only links if the user has permission to drill down further
- Small arrow to go to the link location removed
- Link text underneath title is now a link
- Update PHPUnit

Fixes #153