### PR TITLE
Remove null call to htmlspecialchars

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -45,6 +45,10 @@ defined('MOODLE_INTERNAL') || die();
  * @return string HTML snippet which can be used in output.
  */
 function tool_crawler_link($url, $label, $redirect = '', $labelishtml = false) {
+    if (empty($label)) {
+        // Ensure that label is always at least a string.
+        $label = '';
+    }
     if (!$labelishtml) {
         $label = htmlspecialchars($label, ENT_NOQUOTES | ENT_HTML401);
     }


### PR DESCRIPTION
Before:
```
1) tool_crawler_robot_crawler_test::test_uri_escaping
This test printed output: 
Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/site/admin/tool/crawler/locallib.php on line 49
```

After:
```
root@567c0783abc4:/var/www/site# phpu --filter=tool_crawler
Moodle 4.1.5+ (Build: 20230908), 144d566fc7a02c855775a636199a1728b71ca6c2
Php: 8.1.2.1.2.13, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.1.0-1019-oem x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

............................................................      60 / 60 (100%)

Time: 00:01.973, Memory: 380.00 MB

OK (60 tests, 97 assertions)
```
