### PR TITLE
Update unit tests for Moodle 3.10+

### DIFF
--- a/tests/phpunit/robot_cleanup_test.php
+++ b/tests/phpunit/robot_cleanup_test.php
@@ -44,7 +44,7 @@ class tool_crawler_robot_cleanup_test extends advanced_testcase {
      *
      * @throws coding_exception
      */
-    protected function setUp() {
+    protected function setUp(): void {
         global $DB;
 
         $this->resetAfterTest(true);

--- a/tests/phpunit/robot_crawler_test.php
+++ b/tests/phpunit/robot_crawler_test.php
@@ -42,7 +42,7 @@ class tool_crawler_robot_crawler_test extends advanced_testcase {
     /**
      * Setup robot crawler testcase and parent setup
      */
-    protected function setUp() {
+    protected function setUp():void {
         parent::setup();
         $this->resetAfterTest(true);
 


### PR DESCRIPTION
In Moodle 3.10 - Breaking change: All the "template methods" (setUp(), tearDown()...) now require to return void.
https://github.com/moodle/moodle/blob/master/lib/upgrade.txt#L772