### PR TITLE
Fix #190 - ci badge linking master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# moodle-tool_crawler
+[![ci](https://github.com/catalyst/moodle-tool_crawler/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/catalyst/moodle-tool_crawler/actions/workflows/ci.yml?branch=master)
 
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/catalyst/moodle-tool_crawler/ci/master?label=ci)
+# moodle-tool_crawler
 
 * [What is this?](#what-is-this)
 * [How does it work?](#how-does-it-work)


### PR DESCRIPTION
Fix #190 - ci badge linking master branch