### PR TITLE
Exit early on sigint or cron shutdown #198

### DIFF
--- a/classes/robot/crawler.php
+++ b/classes/robot/crawler.php
@@ -534,6 +534,15 @@ class crawler {
 
         // While we are not exceeding the maxcron time, and the queue is not empty.
         while ($hastime) {
+
+            if (\core\local\cli\shutdown::should_gracefully_exit() ||
+                \core\task\manager::static_caches_cleared_since($cronstart)) {
+                if ($verbose) {
+                    echo "Shutting down crawler early\n";
+                }
+                return true;
+            }
+
             if (empty($nodes)) {
                 // Grab a list of items from the front of the queue. We need the first 1000
                 // in case other workers are already locked and processing items at the front of the queue.

--- a/cli/crawler.php
+++ b/cli/crawler.php
@@ -52,5 +52,7 @@ if ($options['verbose'] && (!is_numeric($options['verbose']) || $options['verbos
     die();
 }
 
+\core\local\cli\shutdown::script_supports_graceful_exit();
+
 tool_crawler_crawl($options['verbose']);
 


### PR DESCRIPTION
Run these and press control c half way through and confirm they exit cleanly and quckly:
```
php admin/tool/crawler/cli/crawler.php 
```

```
# queue up ad hoc tasks:
php admin/cli/scheduled_task.php --execute='\tool_crawler\task\crawl_task'

# now control c half way through this:
php admin/cli/adhoc_task.php --classname='tool_crawler\task\adhoc_crawl_task'
```

Repeat both of above but then instead of control c, in another terminal run this, and they should exit fast:

php admin/cli/cron.php --disable

