### PR TITLE
Require locallib and constants files in setUpBeforeClass

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -23,7 +23,7 @@
  */
 
 use tool_crawler\local\url;
-require_once($CFG->dirroot . '/admin/tool/crawler/constants.php');
+require_once(__DIR__ . '/constants.php');
 
 /**
  * Renders a link as HTML.


### PR DESCRIPTION
**Description:** We are seeing the following errors running the tests in non-local environments. I think this is happening because $CFG has yet to be available. I have checked existing tests in core and they use the committed pattern

```
Warning: Undefined variable $CFG in /var/www/site/admin/tool/crawler/locallib.php on line 26

Warning: Attempt to read property "dirroot" on null in /var/www/site/admin/tool/crawler/locallib.php on line 26

Warning: require_once(/admin/tool/crawler/constants.php): Failed to open stream: No such file or directory in /var/www/site/admin/tool/crawler/locallib.php on line 26

Fatal error: Uncaught Error: Failed opening required '/admin/tool/crawler/constants.php' (include_path='/var/www/site/lib/pear:/var/www/site/lib/pear:.:/usr/share/php') in /var/www/site/admin/tool/crawler/locallib.php:26
Stack trace:
#0 /var/www/site/admin/tool/crawler/tests/phpunit/robot_crawler_test.php(32): require_once()
#1 /var/www/site/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once('/var/www/site/a...')
#2 /var/www/site/vendor/phpunit/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load()
#3 /var/www/site/vendor/phpunit/phpunit/src/Framework/TestSuite.php(398): PHPUnit\Util\FileLoader::checkAndLoad()
#4 /var/www/site/vendor/phpunit/phpunit/src/Framework/TestSuite.php(537): PHPUnit\Framework\TestSuite->addTestFile()
#5 /var/www/site/vendor/phpunit/phpunit/src/TextUI/TestSuiteMapper.php(67): PHPUnit\Framework\TestSuite->addTestFiles()
#6 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(391): PHPUnit\TextUI\TestSuiteMapper->map()
#7 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(114): PHPUnit\TextUI\Command->handleArguments()
#8 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(99): PHPUnit\TextUI\Command->run()
#9 /var/www/site/vendor/phpunit/phpunit/phpunit(107): PHPUnit\TextUI\Command::main()
#10 /var/www/site/vendor/bin/phpunit(122): include('/var/www/site/v...')
#11 {main}

Next PHPUnit\TextUI\RuntimeException: Failed opening required '/admin/tool/crawler/constants.php' (include_path='/var/www/site/lib/pear:/var/www/site/lib/pear:.:/usr/share/php') in /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php:101
Stack trace:
#0 /var/www/site/vendor/phpunit/phpunit/phpunit(107): PHPUnit\TextUI\Command::main()
#1 /var/www/site/vendor/bin/phpunit(122): include('/var/www/site/v...')
#2 {main}
  thrown in /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php on line 101
PHP Warning:  Undefined variable $CFG in /var/www/site/admin/tool/crawler/locallib.php on line 26
PHP Warning:  Attempt to read property "dirroot" on null in /var/www/site/admin/tool/crawler/locallib.php on line 26
PHP Warning:  require_once(/admin/tool/crawler/constants.php): Failed to open stream: No such file or directory in /var/www/site/admin/tool/crawler/locallib.php on line 26
PHP Fatal error:  Uncaught Error: Failed opening required '/admin/tool/crawler/constants.php' (include_path='/var/www/site/lib/pear:/var/www/site/lib/pear:.:/usr/share/php') in /var/www/site/admin/tool/crawler/locallib.php:26
Stack trace:
#0 /var/www/site/admin/tool/crawler/tests/phpunit/robot_crawler_test.php(32): require_once()
#1 /var/www/site/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once('/var/www/site/a...')
#2 /var/www/site/vendor/phpunit/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load()
#3 /var/www/site/vendor/phpunit/phpunit/src/Framework/TestSuite.php(398): PHPUnit\Util\FileLoader::checkAndLoad()
#4 /var/www/site/vendor/phpunit/phpunit/src/Framework/TestSuite.php(537): PHPUnit\Framework\TestSuite->addTestFile()
#5 /var/www/site/vendor/phpunit/phpunit/src/TextUI/TestSuiteMapper.php(67): PHPUnit\Framework\TestSuite->addTestFiles()
#6 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(391): PHPUnit\TextUI\TestSuiteMapper->map()
#7 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(114): PHPUnit\TextUI\Command->handleArguments()
#8 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(99): PHPUnit\TextUI\Command->run()
#9 /var/www/site/vendor/phpunit/phpunit/phpunit(107): PHPUnit\TextUI\Command::main()
#10 /var/www/site/vendor/bin/phpunit(122): include('/var/www/site/v...')
#11 {main}
```