### PR TITLE
Suppress warnings on Status page if configured robot user's id/username

### DIFF
--- a/index.php
+++ b/index.php
@@ -71,10 +71,30 @@ $duration = time() - $crawlstart;
 $eta = floor($duration / $progress + $crawlstart);
 
 $robot = $DB->get_record('user', ['username' => $config->botusername]);
-if (!$robot) {
-    $robot = new stdClass();
-    $robot->id = get_string('botusermissing', 'tool_crawler');
-    $robot->username = get_string('botusermissing', 'tool_crawler');
+$botrowdata = array(get_string('botuser', 'tool_crawler'));
+
+// Do not display links to bot user if it doesn't exist
+if ($robot) {
+    $botrowdata[] = implode(' | ', array(
+        $robot->username,
+        $boterror ? $boterror : get_string('good', 'tool_crawler'),
+        html_writer::link(
+            new moodle_url(
+                '/user/editadvanced.php',
+                ['id' => $robot->id, 'courseid' => 1]
+            ),
+            get_string('useraccount', 'tool_crawler')
+        ),
+        html_writer::link(
+            new moodle_url(
+                '/admin/roles/usersroles.php',
+                ['userid' => $robot->id, 'courseid' => 1]
+            ),
+            get_string('roles')
+        ),
+    ));
+} else {
+    $botrowdata[] = $boterror;
 }
 
 $table = new html_table();
@@ -82,19 +102,7 @@ $table->head = [get_string('robotstatus', 'tool_crawler')];
 $table->headspan = [2, 1];
 $table->attributes['class'] = 'generaltable table table-hover w-auto';
 $table->data = [
-    [
-        get_string('botuser', 'tool_crawler'),
-        $robot->username
-        . ' | ' . ($boterror ? $boterror : get_string('good', 'tool_crawler'))
-        . ' | ' . html_writer::link(new moodle_url(
-            '/user/editadvanced.php',
-            ['id' => $robot->id, 'courseid' => 1]
-        ), get_string('useraccount', 'tool_crawler'))
-        . ' | ' . html_writer::link(new moodle_url(
-            '/admin/roles/usersroles.php',
-            ['userid' => $robot->id, 'courseid' => 1]
-        ), get_string('roles')),
-    ],
+    $botrowdata,
     [
         get_string('progress', 'tool_crawler'),
 

--- a/index.php
+++ b/index.php
@@ -71,6 +71,11 @@ $duration = time() - $crawlstart;
 $eta = floor($duration / $progress + $crawlstart);
 
 $robot = $DB->get_record('user', ['username' => $config->botusername]);
+if (!$robot) {
+    $robot = new stdClass();
+    $robot->id = get_string('botusermissing', 'tool_crawler');
+    $robot->username = get_string('botusermissing', 'tool_crawler');
+}
 
 $table = new html_table();
 $table->head = [get_string('robotstatus', 'tool_crawler')];


### PR DESCRIPTION
doesn't exist yet or is renamed to a username that doesn't exist.