### PR TITLE
Convert test data providers to static, add coverage, fix comment

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ $eta = floor($duration / $progress + $crawlstart);
 $robot = $DB->get_record('user', ['username' => $config->botusername]);
 $botrowdata = [get_string('botuser', 'tool_crawler')];
 
-// Do not display links to bot user if it doesn't exist
+// Do not display links to bot user if it doesn't exist.
 if ($robot) {
     $botrowdata[] = implode(' | ', [
         $robot->username,

--- a/tests/phpunit/robot_cleanup_test.php
+++ b/tests/phpunit/robot_cleanup_test.php
@@ -139,6 +139,8 @@ final class robot_cleanup_test extends \advanced_testcase {
      * Read plugin config params.
      * Execute robot_cleanup scheduled task.
      * Check if only 1 record (out of 3 configured above) is left in table {tool_crawler_url}.
+     *
+     * @covers \tool_crawler\task\robot_cleanup::execute
      */
     public function test_robot_cleanup(): void {
         global $DB;

--- a/tests/phpunit/robot_crawler_test.php
+++ b/tests/phpunit/robot_crawler_test.php
@@ -62,7 +62,7 @@ final class robot_crawler_test extends \advanced_testcase {
      *
      * @return array of test cases
      */
-    public function absolute_urls_provider(): array {
+    public static function absolute_urls_provider(): array {
         return [
             [
                 'base' => 'http://test.com/sub/',
@@ -119,6 +119,8 @@ final class robot_crawler_test extends \advanced_testcase {
      *
      * @param string $base Base part of URL
      * @param array $links Combinations of relative paths of URL and expected result
+     *
+     * @covers \tool_crawler\task\robot_cleanup::execute
      */
     public function test_absolute_urls($base, $links): void {
         foreach ($links as $key => $value) {
@@ -131,7 +133,7 @@ final class robot_crawler_test extends \advanced_testcase {
      *
      * @return array of test cases
      */
-    public function should_auth_provider(): array {
+    public static function should_auth_provider(): array {
         return [
             [false, 'http://my_moodle.com', 'http://evil.com/blah/http://my_moodle.com'],
             [false, 'http://my_moodle.com', 'http://my_moodle.com.actually.im.evil.com'],
@@ -152,6 +154,8 @@ final class robot_crawler_test extends \advanced_testcase {
      * @param bool $expected
      * @param string $myurl URL of current Moodle installation
      * @param string $testurl URL where we should authenticate
+     *
+     * @covers \tool_crawler\robot\crawler::should_be_authenticated
      */
     public function test_should_be_authenticated($expected, $myurl, $testurl): void {
         global $CFG;
@@ -162,6 +166,8 @@ final class robot_crawler_test extends \advanced_testcase {
 
     /**
      * Tests existence of new plugin parameter 'retentionperiod'
+     *
+     * @covers \tool_crawler\robot\crawler
      */
     public function test_param_retention_exists(): void {
         $param = get_config('tool_crawler', 'retentionperiod');
@@ -170,6 +176,8 @@ final class robot_crawler_test extends \advanced_testcase {
 
     /**
      * Regression test for Issue #17
+     *
+     * @covers \tool_crawler\local\url::reset_for_recrawl
      */
     public function test_reset_queries(): void {
         global $DB;
@@ -219,6 +227,8 @@ final class robot_crawler_test extends \advanced_testcase {
     /**
      * Regression test for Issue #48: database must store URI without HTML-escaping, but URI must still be escaped when it is output
      * to an HTML document.
+     *
+     * @covers \tool_crawler\robot\crawler::mark_for_crawl
      */
     public function test_uri_escaping(): void {
         $baseurl = 'http://crawler.test/';
@@ -244,6 +254,8 @@ final class robot_crawler_test extends \advanced_testcase {
 
     /**
      * Regression test for an issue similar to Issue #48: redirection URI must be escaped when it is output to an HTML document.
+     *
+     * @covers \tool_crawler\robot\crawler::parse_html
      */
     public function test_redirection_uri_escaping(): void {
         global $DB;
@@ -291,6 +303,8 @@ final class robot_crawler_test extends \advanced_testcase {
 
     /**
      * Test for Issue #92: specified dom elements in the config should be excluded.
+     *
+     * @covers \tool_crawler\robot\crawler::parse_html
      */
     public function test_should_be_excluded(): void {
         global $DB;
@@ -355,7 +369,7 @@ final class robot_crawler_test extends \advanced_testcase {
      *
      * @return array of potential crawler priority codes.
      */
-    public function priority_provider(): array {
+    public static function priority_provider(): array {
         return [
             ['high' => TOOL_CRAWLER_PRIORITY_HIGH],
             ['normal' => TOOL_CRAWLER_PRIORITY_NORMAL],
@@ -369,6 +383,8 @@ final class robot_crawler_test extends \advanced_testcase {
      * @dataProvider priority_provider
      *
      * @param int $parentpriority the priority of the parent queue item
+     *
+     * @covers \tool_crawler\robot\crawler::parse_html
      */
     public function test_parse_html_priority_inheritance($parentpriority): void {
         global $CFG, $DB;
@@ -433,7 +449,7 @@ HTML;
     /**
      * Test for Issue #120:Specified external urls should be excluded.
      */
-    public function should_be_crawled_provider(): array {
+    public static function should_be_crawled_provider(): array {
         return [
             ['http://moodle.org/', false],
             ['http://validator.w3.org/', false],
@@ -450,6 +466,8 @@ HTML;
      * @dataProvider should_be_crawled_provider
      * @param   string $url
      * @param   bool   $expected
+     *
+     * @covers \tool_crawler\robot\crawler::mark_for_crawl
      */
     public function test_should_be_crawled($url, $expected): void {
         global $CFG;
@@ -471,6 +489,7 @@ HTML;
     /**
      * We must insert the hash of the url whenever we update the tool_crawler_url table.
      *
+     * @covers \tool_crawler\local\url::hash_url
      */
     public function test_url_creates_hash(): void {
         global $DB;
@@ -515,6 +534,7 @@ HTML;
         self::assertTrue(url::hash_url($newurl) === $newurlrecord->urlhash);
         self::assertTrue(url::hash_url($newurl) === $persistent->get('urlhash'));
     }
+
     /**
      * Data provider for string matches
      * This data is taken from the moodle (>3.7) core profiling_string_matches_provider function
@@ -523,7 +543,7 @@ HTML;
      *
      * @return  array
      */
-    public function crawler_url_string_matches_provider(): array {
+    public static function crawler_url_string_matches_provider(): array {
         return [
             ['/index.php', '/index.php', true],
             ['/some/dir/index.php', '/index.php', true], // Different from core function.
@@ -557,6 +577,8 @@ HTML;
      * @param   string $string
      * @param   string $patterns
      * @param   bool   $expected
+     *
+     * @covers \tool_crawler\robot\crawler::crawler_url_string_matches
      */
     public function test_crawler_url_string_matches($string, $patterns, $expected): void {
         $result = $this->robot->crawler_url_string_matches($string, $patterns);
@@ -568,7 +590,7 @@ HTML;
      *
      * @return  array
      */
-    public function url_validity_check_provider(): array {
+    public static function url_validity_check_provider(): array {
         return [
             ['/index.php', true],
             ['/some/dir/index.php', true],
@@ -585,6 +607,8 @@ HTML;
      *
      * @param string $url the url to test
      * @param bool $expected the expected result
+     *
+     * @covers \tool_crawler\robot\crawler::mark_for_crawl
      */
     public function test_invalid_url($url, $expected): void {
         $baseurl = 'https://www.example.com/moodle';
@@ -601,7 +625,7 @@ HTML;
      *
      * @return  array
      */
-    public function page_title_validity_check_provider(): array {
+    public static function page_title_validity_check_provider(): array {
         return [
             [['contents' => '<title>Invalid <i>title</i><title><body></body>'], 'Invalid title'],
             [['contents' => '<title>Valid title<title><body></body>'], 'Valid title'],
@@ -615,6 +639,8 @@ HTML;
      *
      * @param array $node The node to test.
      * @param string $expected
+     *
+     * @covers \tool_crawler\robot\crawler::parse_html
      */
     public function test_check_page_title_validity($node, $expected): void {
         $this->resetAfterTest(true);


### PR DESCRIPTION
**Description:** Fix codechecker issues:

### Before
```
Run moodle-plugin-ci codechecker --max-warnings=-1
 RUN  Moodle CodeSniffer standard on tool_crawler
............W..............WWW..E 33 / 33 (100%)



FILE: /home/runner/work/moodle-tool_crawler/moodle-tool_crawler/moodle/admin/tool/crawler/classes/robot/crawler.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 694 | WARNING | Function utf8_decode() has been deprecated (moodle.PHP.DeprecatedFunctions.Deprecated)
 694 | WARNING | Function utf8_decode() is deprecated since PHP 8.2; Use mb_convert_encoding(), UConverter::transcode() or iconv
     |         | instead (PHPCompatibility.FunctionUse.RemovedFunctions.utf8_decodeDeprecated)
------------------------------------------------------------------------------------------------------------------------------------


FILE: /home/runner/work/moodle-tool_crawler/moodle-tool_crawler/moodle/admin/tool/crawler/lang/en/tool_crawler.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 4 LINES
------------------------------------------------------------------------------------------------------------------------------------
 200 | WARNING | Unexpected comment found. Auto-fixing will not work after this comment
     |         | (moodle.Files.LangFilesOrdering.UnexpectedComment)
 201 | WARNING | Unexpected comment found. Auto-fixing will not work after this comment
     |         | (moodle.Files.LangFilesOrdering.UnexpectedComment)
 202 | WARNING | Unexpected comment found. Auto-fixing will not work after this comment
     |         | (moodle.Files.LangFilesOrdering.UnexpectedComment)
 203 | WARNING | The string key "privacy:no_data_reason" is not in the correct order, it should be before "whenqueued"
     |         | (moodle.Files.LangFilesOrdering.IncorrectOrder)
------------------------------------------------------------------------------------------------------------------------------------


FILE: /home/runner/work/moodle-tool_crawler/moodle-tool_crawler/moodle/admin/tool/crawler/tests/phpunit/robot_crawler_test.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 20 WARNINGS AFFECTING 20 LINES
------------------------------------------------------------------------------------------------------------------------------------
  65 | WARNING | Data provider method "absolute_urls_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 123 | WARNING | Test method test_absolute_urls() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 134 | WARNING | Data provider method "should_auth_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 156 | WARNING | Test method test_should_be_authenticated() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 166 | WARNING | Test method test_param_retention_exists() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 174 | WARNING | Test method test_reset_queries() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 223 | WARNING | Test method test_uri_escaping() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 248 | WARNING | Test method test_redirection_uri_escaping() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 295 | WARNING | Test method test_should_be_excluded() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 358 | WARNING | Data provider method "priority_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 373 | WARNING | Test method test_parse_html_priority_inheritance() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 436 | WARNING | Data provider method "should_be_crawled_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 454 | WARNING | Test method test_should_be_crawled() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 475 | WARNING | Test method test_url_creates_hash() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 526 | WARNING | Data provider method "crawler_url_string_matches_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 561 | WARNING | Test method test_crawler_url_string_matches() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 571 | WARNING | Data provider method "url_validity_check_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 589 | WARNING | Test method test_invalid_url() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
 604 | WARNING | Data provider method "page_title_validity_check_provider" will need to be converted to static in future.
     |         | (moodle.PHPUnit.TestCaseProvider.dataProviderNotStatic)
 619 | WARNING | Test method test_check_page_title_validity() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
------------------------------------------------------------------------------------------------------------------------------------


FILE: /home/runner/work/moodle-tool_crawler/moodle-tool_crawler/moodle/admin/tool/crawler/tests/phpunit/robot_cleanup_test.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 143 | WARNING | Test method test_robot_cleanup() is missing any coverage information, own or at class level
     |         | (moodle.PHPUnit.TestCaseCovers.Missing)
------------------------------------------------------------------------------------------------------------------------------------
```

### After

```
Running CodeSniffer for ltu on plugin admin/tool/crawler with standard moodle
 RUN  Moodle CodeSniffer standard on tool_crawler
.....W........................... 33 / 33 (100%)



FILE: /var/www/site/admin/tool/crawler/classes/robot/crawler.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 694 | WARNING | Function utf8_decode() has been deprecated (moodle.PHP.DeprecatedFunctions.Deprecated)
 694 | WARNING | Function utf8_decode() is deprecated since PHP 8.2; Use mb_convert_encoding(), UConverter::transcode() or iconv
     |         | instead (PHPCompatibility.FunctionUse.RemovedFunctions.utf8_decodeDeprecated)
------------------------------------------------------------------------------------------------------------------------------------

Time: 1.92 secs; Memory: 28MB
```